### PR TITLE
style(icons): :bug: corregir uso de '#' por '.' en la clase de un icono

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "conventionalCommits.scopes": [
         "page",
-        "enlaces"
+        "enlaces",
+        "footer"
     ]
 }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
   <meta name="description" content="Create mobile apps for your business in just minutes. No code, no delay, no cost.">
   <meta name="keywords" content="Mobile apps, mobile app development, app development tools">
   <meta property="og:title" content="Relevo Tableros Eléctricos">
@@ -48,14 +49,6 @@
           target="_blank" rel="noopener noreferrer">
           <!-- Seguridad contra tabnabbing + privacidad (es la mejor práctica). -->
           <span>MULTIPLACA: PB T-G 01</span>
-          <img src="./assets/icons/arrow.png" alt="arrow">
-        </a>
-      </li>
-
-      <li title="TABLERO ELÉCTRICO">
-        <a class="links" href="https://1drv.ms/b/c/4deddb1a6d1d3453/IQTAdkXcC2GyQq_NMyooht1XAQZh-4vqtLu1vRO6WbOEgFw"
-          target="_blank" rel="noopener noreferrer">
-          <span>MULTIPLACA: PB T-G 02</span>
           <img src="./assets/icons/arrow.png" alt="arrow">
         </a>
       </li>

--- a/src/css/page.css
+++ b/src/css/page.css
@@ -121,7 +121,7 @@ html {
     align-items: center;
     gap: var(--gap-10);
 
-    & #icons-chevron {
+    & .icons-chevron {
       transform: rotate(-90deg);
       width: 23px;
     }


### PR DESCRIPTION
Se reemplazó el uso de '#' (id) por '.' (class) en el icono, ya que el selector estaba mal definido y no se aplicaban los estilos correctamente.  Con este cambio los íconos ahora cargan y muestran el estilo esperado.

Closes: No hay