### PR TITLE
fix(meta): :bug: corregida búsqueda de sede con guiones en meta_description.js

### DIFF
--- a/404.html
+++ b/404.html
@@ -62,7 +62,8 @@ Qué hace este 404.html:
         const partes = path.split("/");
         let sede = partes[partes.length - 1];
 
-        sede = decodeURIComponent(sede.replace(/-/g, " "));
+        // 🔹 Mantener los guiones (no reemplazarlos por espacios)
+        sede = decodeURIComponent(sede);
 
         if (!sede) {
           document.body.innerHTML = "<h2>No se especificó sede.</h2>";

--- a/src/js/meta_description.js
+++ b/src/js/meta_description.js
@@ -18,7 +18,8 @@
       }
     }
 
-    const registro = datos.find((item) => item.sede === sedeActual);
+    const normalizar = s => s.toLowerCase().replace(/\s+/g, "-").trim();
+    const registro = datos.find(item => normalizar(item.sede) === normalizar(sedeActual));
 
     if (!registro) {
       console.warn("No se encontró tablero para esta sede:", sedeActual);


### PR DESCRIPTION


- Se normaliza el nombre de la sede reemplazando espacios por guiones antes de comparar. 
- Ahora las URLs con formato VICENTE-LÓPEZ-2 coinciden correctamente con "VICENTE LÓPEZ 2" del JSON. 
- Soluciona el error "No se encontraron tableros para esta sede".