### PR TITLE
feat(QR): :sparkles: Generar página dinámica de QRs desde JSON

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,8 @@
         "estructura",
         "rutas",
         "404",
-        "meta"
+        "meta",
+        "QR"
     ],
     "cSpell.words": [
         "ADELINA",

--- a/organizar_qr.html
+++ b/organizar_qr.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tableros - QRs</title>
+  <link rel="stylesheet" href="./src/css/organizar_qr.css">
+
+  <!-- Favicons -->
+  <link rel="shortcut icon" href="./assets/icons/logo-cosaca.png" type="image/png">
+  <link rel="icon" href="./assets/icons/logo-cosaca.png" type="image/png">
+  <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/logo-cosaca.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="./assets/icons/logo-cosaca.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="./assets/icons/logo-cosaca.png">
+  <meta name="mobile-web-app-capable" content="yes">
+</head>
+
+<body>
+  <h1>Tableros - QRs</h1>
+  <div class="grid-container" id="grid-container"></div>
+
+  <script>
+    // Cargar JSON de tableros
+    fetch('./data/tableros_completo.json')
+      .then(response => response.json())
+      .then(data => {
+        const container = document.getElementById('grid-container');
+        data.datos.forEach(tablero => {
+          const card = document.createElement('div');
+          card.className = 'qr-card';
+
+          // Insertar QR como imagen (puede ser SVG o PNG)
+          const qrImg = document.createElement('img');
+          qrImg.src = tablero.qr;
+          qrImg.alt = tablero["id del tablero"];
+          card.appendChild(qrImg);
+
+          // Nombre + icono
+          const nameDiv = document.createElement('div');
+          nameDiv.className = 'qr-name';
+
+          // Reemplazamos solo el primer ":" por ":\n"
+          const idConSalto = tablero["id del tablero"].replace(':', ':\n');
+
+          nameDiv.innerHTML = `<img src="./assets/icons/logo-cosaca.png" alt="Icono Cosaca">${idConSalto}`;
+card.appendChild(nameDiv);
+
+          container.appendChild(card);
+        });
+      })
+      .catch(err => console.error("Error cargando tableros:", err));
+  </script>
+</body>
+
+</html>

--- a/src/css/organizar_qr.css
+++ b/src/css/organizar_qr.css
@@ -1,0 +1,51 @@
+/* variables.css */
+@import url('variables.css');
+
+body {
+  font-family: Arial;
+  padding: 20px;
+  background: var(--color-white);
+}
+
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: var(--gap-20);
+}
+
+.qr-card {
+  background: var(--color-white);
+  border-radius: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  padding: 10px;
+  text-align: center;
+}
+
+.qr-card img {
+  border-bottom: 2px solid var(--color-primary);
+  width: 120px;
+  height: 120px;
+  margin-bottom: 10px;
+  object-fit: contain;
+}
+
+.qr-name {
+  display: flex;
+  flex-direction: column;
+  /* vertical para texto con salto de línea */
+  align-items: center;
+  /* centra horizontalmente el texto */
+  justify-content: center;
+  gap: 5px;
+  font-weight: bold;
+  font-size: 12px;
+  white-space: pre-wrap;
+  /* respeta los saltos de línea */
+  text-align: center;
+}
+
+.qr-name img {
+  border-bottom: none;
+  width: 40px;
+  height: 40px;
+}

--- a/src/css/page.css
+++ b/src/css/page.css
@@ -1,54 +1,5 @@
-* {
-  box-sizing: border-box;
-  margin: 0px;
-  padding: 0px;
-  list-style: none;
-  text-decoration: none;
-}
-*:focus {
-  outline: none;
-  -webkit-tap-highlight-color: transparent;
-  user-select: none;
-  touch-action: none;
-}
-html {
-  scroll-behavior: smooth;
-  font-size: 62.5%;
-  background: var(--color-fondo);
-}
-
-/* Variables CSS globales (colores, fuentes) */
-
-:root {
-  /* VARIABLES DE COLORES */
-  --color-fondo: #f9fafb;
-  --color-primary: #c00000;
-  --color-white: #ffffffff;
-  --color-brack: #00000088;
-  --color-caja-url: #e4e1e1ff;
-  --color-footer: #26272b;
-
-  --color-caja-url-hover: #d8d7d7ff;
-  --color-azul-hover: #2c2c7de6;
-  --color-borde-caja: #9b9b9bff;
-
-  /* VARIABLES FUENTES */
-  --family-primary: "Roboto", monospace, sans-serif;
-  --family-secondary: "Montserrat", monospace, sans-serif;
-
-  /* VARIABLES DE TAMAÑO */
-  --size-12: 1.2rem;
-  --size-14: 1.4rem;
-  --size-16: 1.6rem;
-  --size-20: 2rem;
-  --gap-10: 10px;
-  --gap-20: 20px;
-
-  /* VARIABLES DE ASPECTO */
-  --border-radius-08: 8px;
-  --border-radius-10: 10px;
-  --border-radius-12: 12px;
-}
+/* variables.css */
+@import url('variables.css');
 
 .body {
   height: 100vh;

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -1,0 +1,51 @@
+* {
+  box-sizing: border-box;
+  margin: 0px;
+  padding: 0px;
+  list-style: none;
+  text-decoration: none;
+}
+*:focus {
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  touch-action: none;
+}
+html {
+  scroll-behavior: smooth;
+  font-size: 62.5%;
+  background: var(--color-fondo);
+}
+
+/* Variables CSS globales (colores, fuentes) */
+
+:root {
+  /* VARIABLES DE COLORES */
+  --color-fondo: #f9fafb;
+  --color-primary: #c00000;
+  --color-white: #ffffffff;
+  --color-brack: #00000088;
+  --color-caja-url: #e4e1e1ff;
+  --color-footer: #26272b;
+
+  --color-caja-url-hover: #d8d7d7ff;
+  --color-azul-hover: #2c2c7de6;
+  --color-borde-caja: #9b9b9bff;
+
+  /* VARIABLES FUENTES */
+  --family-primary: "Roboto", monospace, sans-serif;
+  --family-secondary: "Montserrat", monospace, sans-serif;
+
+  /* VARIABLES DE TAMAÑO */
+  --size-12: 1.2rem;
+  --size-14: 1.4rem;
+  --size-16: 1.6rem;
+  --size-20: 2rem;
+  --gap-10: 10px;
+  --gap-20: 20px;
+
+  /* VARIABLES DE ASPECTO */
+  --border-radius-08: 8px;
+  --border-radius-10: 10px;
+  --border-radius-12: 12px;
+}


### PR DESCRIPTION
- Se creó una página HTML que carga todos los QR de tableros desde `tableros_completo.json`. 
- Cada QR se muestra en un contenedor `.qr-card` con sombra y borde redondeado. 
- Se agregó el icono de Cosaca antes del ID del tablero. 
- El texto del ID del tablero ahora tiene un salto de línea después del primer ":". 
- Se utiliza CSS Grid para organizar los QR automáticamente según el ancho de pantalla. 
- Se agregó `white-space: pre-wrap` para respetar los saltos de línea en los nombres.