### PR TITLE
chore(git): :bug: renombrar rama feature/creaciónQR → feature/creacion-qr para evitar caracteres Unicode en la referencia

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,8 @@
         "rutas",
         "404",
         "meta",
-        "QR"
+        "QR",
+        "git"
     ],
     "cSpell.words": [
         "ADELINA",


### PR DESCRIPTION
renombrar rama feature/creaciónQR → feature/creacion-qr para evitar caracteres Unicode en la referencia